### PR TITLE
Add --disable-tests flags to mono-upnp configure.ac

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,10 +5,16 @@ EXTRA_DIST = \
 
 #Warning: This is an automatically generated file, do not edit!
 if ENABLE_DEBUG
- SUBDIRS =  src/Mono.Ssdp/Mono.Ssdp src/Mono.Upnp src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1 tests
+ SUBDIRS =  src/Mono.Ssdp/Mono.Ssdp src/Mono.Upnp src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1 
+if ENABLE_TESTS
+ SUBDIRS +=  tests
+endif
 endif
 if ENABLE_RELEASE
- SUBDIRS =  src/Mono.Ssdp/Mono.Ssdp src/Mono.Upnp src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1 tests
+ SUBDIRS =  src/Mono.Ssdp/Mono.Ssdp src/Mono.Upnp src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1
+if ENABLE_TESTS
+ SUBDIRS +=  tests
+endif
 endif
 
 .PHONY: test

--- a/configure.ac
+++ b/configure.ac
@@ -51,11 +51,17 @@ PKG_CHECK_MODULES([GLIB_SHARP_20], [glib-sharp-2.0])
 PKG_CHECK_MODULES([GLADE_SHARP_20], [glade-sharp-2.0])
 PKG_CHECK_MODULES([MONO_ADDINS], [mono-addins])
 PKG_CHECK_MODULES([TAGLIB_SHARP], [taglib-sharp])
-PKG_CHECK_MODULES([NUNIT], [nunit])
 
-AC_PATH_PROG(NUNIT_CMD, nunit-console2, nunit-console)
-AC_SUBST(NUNIT_CMD)
-
+AC_ARG_ENABLE(tests,
+	AC_HELP_STRING([--enable-tests],
+		[Build nunit tests [default=YES]]),
+		[], enable_tests=yes)
+	AM_CONDITIONAL(ENABLE_TESTS, test x$enable_tests = xyes)
+	if test "x$enable_tests" = "xyes" ; then
+		PKG_CHECK_MODULES([NUNIT], [nunit])
+		AC_PATH_PROG(NUNIT_CMD, nunit-console2, nunit-console)
+		AC_SUBST(NUNIT_CMD)
+	fi
 
 AC_CONFIG_FILES([
 src/Mono.Ssdp/Mono.Ssdp/mono.ssdp.pc


### PR DESCRIPTION
By default, NUnit tests are still build but packagers (and builders on
OS X) can specify --disable-tests to omit the check and thus won't need
to install NUnit prior to building.

I know, the toplevel Makefile.am was initially auto-generated by MonoDevelop and says "do not edit". Altough I've tried a little with MonoDevelop 3 and whatever I did (adding files, projects, configurations) the toplevel Makefile.am was never touched by MD. Only subproject's Makefile.am were regenerated, so I think its safe to put the changes in there.
