### PR TITLE
Dispose timeouts when disposing ServiceCache

### DIFF
--- a/src/Mono.Ssdp/Mono.Ssdp/Mono.Ssdp.Internal/ServiceCache.cs
+++ b/src/Mono.Ssdp/Mono.Ssdp/Mono.Ssdp.Internal/ServiceCache.cs
@@ -56,6 +56,7 @@ namespace Mono.Ssdp.Internal
         public void Dispose ()
         {
             lock (mutex) {
+                timeouts.Dispose();
                 if (services != null) {
                     services.Clear ();
                     services = null;


### PR DESCRIPTION
When Client object ref is disposed before all ServiceCache services timeout callbacks have been processed exception is thrown:
System.NullReferenceException: Object reference not set to an instance of an object.
   at Mono.Ssdp.Internal.ServiceCache.Remove(String usn, Boolean fromTimeout)
   at Mono.Ssdp.Internal.ServiceCache.TimeoutHandler(Object state, TimeSpan& interval)
   at Mono.Ssdp.Internal.TimeoutDispatcher.TimerThread(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()

This commit addresses such scenarios with calling Dispose on timeouts when ServiceCache Dispose is called.
