### PR TITLE
build: Use mcs instead of gmcs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,9 +17,9 @@ SHAMROCK_EXPAND_DATADIR
 
 AC_PROG_INSTALL
 
-AC_PATH_PROG(GMCS, gmcs, no)
-if test "x$GMCS" = "xno"; then
-        AC_MSG_ERROR([gmcs Not found])
+AC_PATH_PROG(MCS, mcs, no)
+if test "x$MCS" = "xno"; then
+        AC_MSG_ERROR([mcs Not found])
 fi
 
 

--- a/src/Mono.Ssdp/Mono.Ssdp/Mono.Ssdp.make
+++ b/src/Mono.Ssdp/Mono.Ssdp/Mono.Ssdp.make
@@ -3,7 +3,7 @@
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG" "-keyfile:$(srcdir)/mono-ssdp.snk"
 ASSEMBLY = ../../../bin/Mono.Ssdp.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -17,7 +17,7 @@ MONO_SSDP_DLL_MDB=$(BUILD_DIR)/Mono.Ssdp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+ "-keyfile:$(srcdir)/mono-ssdp.snk"
 ASSEMBLY = ../../../bin/Mono.Ssdp.dll
 ASSEMBLY_MDB = 

--- a/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MSMediaReceiverRegistrar1/Makefile.am
+++ b/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MSMediaReceiverRegistrar1/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MSMediaReceiverRegistrar1.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -25,7 +25,7 @@ MONO_UPNP_DLL_MDB=$(BUILD_DIR)/Mono.Upnp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY = MSMediaServerRegistrar1.dll
 ASSEMBLY_MDB = 

--- a/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer/Makefile.am
+++ b/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer.exe
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -39,7 +39,7 @@ MSMEDIASERVERREGISTRAR1_DLL=
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer.exe
 ASSEMBLY_MDB = 

--- a/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer/Options.cs
+++ b/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer/Mono.Upnp.Dcp.MediaServer1.FileSystem.ConsoleServer/Options.cs
@@ -27,8 +27,8 @@
 //
 
 // Compile With:
-//   gmcs -debug+ -r:System.Core Options.cs -o:NDesk.Options.dll
-//   gmcs -debug+ -d:LINQ -r:System.Core Options.cs -o:NDesk.Options.dll
+//   mcs -debug+ -r:System.Core Options.cs -o:NDesk.Options.dll
+//   mcs -debug+ -d:LINQ -r:System.Core Options.cs -o:NDesk.Options.dll
 //
 // The LINQ version just changes the implementation of
 // OptionSet.Parse(IEnumerable<string>), and confers no semantic changes.

--- a/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.FileSystem/Makefile.am
+++ b/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.FileSystem/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG" "-keyfile:$(srcdir)/mono-upnp-dcp-mediaserver1-filesystem.snk"
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.FileSystem.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -29,7 +29,7 @@ MONO_UPNP_DCP_MEDIASERVER1_DLL_MDB=$(BUILD_DIR)/Mono.Upnp.Dcp.MediaServer1.dll.m
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+ "-keyfile:$(srcdir)/mono-upnp-dcp-mediaserver1-filesystem.snk"
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.FileSystem.dll
 ASSEMBLY_MDB = 

--- a/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.GtkClient/Makefile.am
+++ b/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1.GtkClient/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.GtkClient.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -33,7 +33,7 @@ MONO_UPNP_GTKCLIENT_EXE_MDB=$(BUILD_DIR)/Mono.Upnp.GtkClient.exe.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize-
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.GtkClient.dll
 ASSEMBLY_MDB = 

--- a/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1/Makefile.am
+++ b/src/Mono.Upnp.Dcp/Mono.Upnp.Dcp.MediaServer1/Mono.Upnp.Dcp.MediaServer1/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug -define:DEBUG "-define:DEBUG,TRACE" "-keyfile:$(srcdir)/mono-upnp-dcp-mediaserver1.snk"
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -25,7 +25,7 @@ MONO_UPNP_DLL_MDB=$(BUILD_DIR)/Mono.Upnp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+ "-keyfile:$(srcdir)/mono-upnp-dcp-mediaserver1.snk"
 ASSEMBLY = ../../../../bin/Mono.Upnp.Dcp.MediaServer1.dll
 ASSEMBLY_MDB = 

--- a/src/Mono.Upnp/Mono.Upnp.GtkClient/Makefile.am
+++ b/src/Mono.Upnp/Mono.Upnp.GtkClient/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = ../../../bin/Mono.Upnp.GtkClient.exe
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -25,7 +25,7 @@ MONO_UPNP_DLL_MDB=$(BUILD_DIR)/Mono.Upnp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY = ../../../bin/Mono.Upnp.GtkClient.exe
 ASSEMBLY_MDB = 

--- a/src/Mono.Upnp/Mono.Upnp/Makefile.am
+++ b/src/Mono.Upnp/Mono.Upnp/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug -define:DEBUG "-define:DEBUG,TRACE" "-keyfile:$(srcdir)/mono-upnp.snk"
 ASSEMBLY = ../../../bin/Mono.Upnp.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -21,7 +21,7 @@ MONO_SSDP_DLL_MDB=$(BUILD_DIR)/Mono.Ssdp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+ "-keyfile:$(srcdir)/mono-upnp.snk"
 ASSEMBLY = ../../../bin/Mono.Upnp.dll
 ASSEMBLY_MDB = 

--- a/tests/Mono.Ssdp.Tests/Makefile.am
+++ b/tests/Mono.Ssdp.Tests/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = ../../bin/Mono.Ssdp.Tests.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -22,7 +22,7 @@ MONO_SSDP_DLL_MDB=$(BUILD_DIR)/Mono.Ssdp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY = ../../bin/Mono.Ssdp.Tests.dll
 ASSEMBLY_MDB = 

--- a/tests/Mono.Ssdp.Tests/Mono.Ssdp.Tests.make
+++ b/tests/Mono.Ssdp.Tests/Mono.Ssdp.Tests.make
@@ -3,7 +3,7 @@
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = Mono.Ssdp.Tests.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -21,7 +21,7 @@ MONO_SSDP_DLL_MDB=$(BUILD_DIR)/Mono.Ssdp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY = Mono.Ssdp.Tests.dll
 ASSEMBLY_MDB = 

--- a/tests/Mono.Upnp.Dcp.MediaServer1.FileSystem.Tests/Makefile.am
+++ b/tests/Mono.Upnp.Dcp.MediaServer1.FileSystem.Tests/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = ../../bin/Mono.Upnp.Dcp.MediaServer1.FileSystem.Tests.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -33,7 +33,7 @@ MONO_UPNP_DCP_MEDIASERVER1_FILESYSTEM_DLL_MDB=$(BUILD_DIR)/Mono.Upnp.Dcp.MediaSe
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY = ../../bin/Mono.Upnp.Dcp.MediaServer1.FileSystem.Tests.dll
 ASSEMBLY_MDB = 

--- a/tests/Mono.Upnp.Dcp.MediaServer1.Tests/Makefile.am
+++ b/tests/Mono.Upnp.Dcp.MediaServer1.Tests/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG" "-keyfile:$(srcdir)/mono-upnp-dcp-mediaserver1-tests.snk"
 ASSEMBLY = ../../bin/Mono.Upnp.Dcp.MediaServer1.Tests.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -29,7 +29,7 @@ MONO_UPNP_DCP_MEDIASERVER1_DLL_MDB=$(BUILD_DIR)/Mono.Upnp.Dcp.MediaServer1.dll.m
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- "-keyfile:$(srcdir)/mono-upnp-dcp-mediaserver1-tests.snk"
 ASSEMBLY = ../../bin/Mono.Upnp.Dcp.MediaServer1.Tests.dll
 ASSEMBLY_MDB = 

--- a/tests/Mono.Upnp.Tests/Makefile.am
+++ b/tests/Mono.Upnp.Tests/Makefile.am
@@ -4,7 +4,7 @@ EXTRA_DIST =
 # Warning: This is an automatically generated file, do not edit!
 
 if ENABLE_DEBUG
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize- -debug "-define:DEBUG"
 ASSEMBLY = ../../bin/Mono.Upnp.Tests.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
@@ -26,7 +26,7 @@ MONO_UPNP_DLL_MDB=$(BUILD_DIR)/Mono.Upnp.dll.mdb
 endif
 
 if ENABLE_RELEASE
-ASSEMBLY_COMPILER_COMMAND = gmcs
+ASSEMBLY_COMPILER_COMMAND = mcs
 ASSEMBLY_COMPILER_FLAGS =  -noconfig -codepage:utf8 -warn:4 -optimize+
 ASSEMBLY = ../../bin/Mono.Upnp.Tests.dll
 ASSEMBLY_MDB = 


### PR DESCRIPTION
as there is no gmcs in recent releases of mono

NB. I'm not sure if we need to do more than change "gmcs" usages to "mcs" ? it compiles OK but I wonder if there are profile versioning issues we need to be aware of?

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>