### PR TITLE
Fixed typographical error, changed archetecture to architecture in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ About the projects:
 * Mono.Ssdp: An implementation of the Simple Discovery Protocol (see UPnP Device
   Architecture 1.1, Section 1).
 
-* Mono.Upnp: An implementation of the UPnP Device Archetecture 1.1, Secions 2-5.
+* Mono.Upnp: An implementation of the UPnP Device Architecture 1.1, Secions 2-5.
 
 * Mono.Upnp.GtkClient: An executable GTK+ user interface for inspecting UPnP
   devices and services on the network.


### PR DESCRIPTION
@mono, I've corrected a typographical error in the documentation of the [mono-upnp](https://github.com/mono/mono-upnp) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.